### PR TITLE
Review of Pipelines II

### DIFF
--- a/responses/11-targets-debug.md
+++ b/responses/11-targets-debug.md
@@ -12,7 +12,7 @@ In `targets`, you can't set a breakpoint in the "normal" way, which would be cli
 
 ---
 
-You have a working, albeit brittle, pipeline in your course repository. You can try it out with `targets::tar_make()`. This pipeline has a number of things you'll work to fix later, but for now, it is a useful reference. The pipeline contains a _targets.R file and several functions defined in `.R` files. 
+You have a working, albeit brittle, pipeline in your course repository. You can try it out with `targets::tar_make()`. This pipeline has a number of things you'll work to fix later, but for now, it is a useful reference. The pipeline contains a `_targets.R` file and several functions defined in `.R` files. 
 
 So, if you wanted to look at what `download_files` were created within the `download_nwis_data()` function, you could set a breakpoint by adding `browser()` to the `"1_fetch/src/get_nwis_data.R"` file (make sure to hit save for changes to take affect!). Hint: to quickly navigate to this function source code from your makefile, you can put your cursor on the name of the function then click F2 and it will take you to the correct location in the corresponding source file!
 

--- a/responses/13-target-status.md
+++ b/responses/13-target-status.md
@@ -34,7 +34,7 @@ In the case of fixed arguments, changing the argument names, values, _or even th
 
 ---
 
-:keyboard: using `tar_vistnetwork()` and `tar_outdated()` can reveal unexpected connections between the target and the various dependencies. Comment on some of the different information you'd get from `tar_visnetwork()` that wouldn't be available in the output produced by `tar_glimpse()` or `tar_manifest()`.
+:keyboard: using `tar_visnetwork()` and `tar_outdated()` can reveal unexpected connections between the target and the various dependencies. Comment on some of the different information you'd get from `tar_visnetwork()` that wouldn't be available in the output produced by `tar_glimpse()` or `tar_manifest()`.
 
 <hr>
 <h3 align="center">I'll sit patiently until you comment</h3>

--- a/responses/17-target-objects.md
+++ b/responses/17-target-objects.md
@@ -43,7 +43,7 @@ Objects used in the command for `tar_target()` need to be created somewhere befo
 
 ---
 
-Another example of when this object (rather than target) pattern comes in handy is when we want to _force_ a target to rebuild. 
+Another example of when this object (rather than target) pattern comes in handy is when we want to _force_ a target to rebuild. Note that in the example below, we are writing the `command` for this target by putting two lines of code between `{}` rather than calling a separate custom function. You can do this for any target, but it is especially useful in this application when we just have two lines of code to execute.
 
 ```r
 library(targets)


### PR DESCRIPTION
In addition to the small text changes:

- There is a reference to `scmake` in the error message of function `download_nwis_site_data`
- In the following code chunk, it might be helpful to explain that we're just writing the command to `work_files` in the `tar_target` function instead of calling a script/function that's elsewhere. Might be confusing to see these brackets and two lines of code.

```
list(
  tar_target(
    work_files,
    {
      dummy <- '2021-04-19'
      item_file_download(sb_id = "4f4e4acae4b07f02db67d22b", 
                         dest_dir = "1_fetch/tmp",
                         overwrite_file = TRUE)
    },
    format = "file",
    packages = "sbtools"
  )
)
```

- I'm got stuck on the first challenge, which is modify the `sites_data` target to potentially be one target per site (I think that's what you're getting at). When one target failed from the random timeout error, I could never get past the timeout error. `targets` is generating a seed based on a hash I think, so you can't change the random seed unless you change upstream dependences. My solution looked like this: 

```
 tar_target(
    site_data_01427207,
    download_nwis_data(site_nums = '01427207'),
  ),
  tar_target(
    site_data_01432160,
    download_nwis_data(site_nums = '01432160'),
```
But once it failed on a target, it would always fail on that target. I ran `tar_make()` about 20x and it failed every time...which I think the chance of is very very low. 

![image](https://user-images.githubusercontent.com/15788176/118750020-3f951380-b824-11eb-9df7-5b937e80f31f.png)

The random seed is reported in `meta` 

![image](https://user-images.githubusercontent.com/15788176/118810861-f7044700-b871-11eb-97a1-6388c2eb6a5e.png)

And I cannot get that seed to change unless I change a dependency of the target (even using `tar_invalidate` results in the same seed). I think my conclusion is that we need to change the way we're randomly generating an error :).

